### PR TITLE
refactor: migrate hero component into main page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,50 @@
 'use client'
-
+import Image from 'next/image'
+import Link from 'next/link'
 import React from 'react'
+import HeroImage from '@/public/images/Concrete_Catholic-86.jpg'
 
 export default function ConcreteCatholicPage() {
   return (
     <>
+      <section id="hero-section" className="w-full self-center bg-cc-charcoal text-white">
+        <div className="container mx-auto pt-24">
+          <div className="grid grid-cols-2">
+            <div className="relative z-20 flex flex-col content-center justify-center">
+              <div className="mb-4 uppercase text-inherit opacity-70">
+                A podcast for the Every day Catholic
+              </div>
+              <div className="max-w-[47.50rem] overflow-hidden pb-1.5 text-7xl font-extrabold">
+                <h1 className="max-w-[50.00rem] pb-3.5 pt-6">
+                  When was the last time you had an encounter with Christ?
+                </h1>
+              </div>
+              <p className="mb-8 max-w-[37.50rem] overflow-visible text-lg">
+                Encounter begins with a simple prayer. Let us begin.
+              </p>
+              <div className="flex items-center gap-8">
+                <Link
+                  className="relative max-w-full cursor-pointer overflow-hidden rounded-sm bg-white px-8 py-3 text-xl text-orange-400"
+                  href="/#"
+                >
+                  Listen Now
+                </Link>
+                <Link
+                  href="/#"
+                  className="relative inline-block max-w-full cursor-pointer overflow-hidden text-xl text-orange-400"
+                >
+                  Meet Fr. Jack Knight
+                </Link>
+              </div>
+            </div>
+            <div className="relative flex h-[80vh] w-[40vw] max-w-[46.88rem] flex-col items-center justify-center bg-zinc-700">
+              <div className="mb-12 ml-12 mr-6 mt-6 inline-block h-full max-h-[56.25rem] w-[37.00rem] max-w-none pb-3 align-middle">
+                <Image src={HeroImage} alt="Fr. Jack Knight sitting in a local brewery." />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
       <section className="flex flex-col w-full max-md:max-w-full">
         <div className="flex flex-col w-full min-h-[998px] max-md:max-w-full">
           <div className="flex flex-1 w-full bg-gray-800 min-h-[934px] max-md:max-w-full" />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,19 +1,16 @@
-import Image from "next/image";
-import { BtnMain } from "./BtnMain";
-import { LinkMain } from "./LinkMain";
-import { Eyebrow } from "./Eyebrow";
-import HeroImage from "@/public/images/Concrete_Catholic-86.jpg";
+import Image from 'next/image'
+import Link from 'next/link'
+import HeroImage from '@/public/images/Concrete_Catholic-86.jpg'
 
 export function Hero() {
   return (
-    <section
-      id="hero-section"
-      className="w-full self-center bg-cc-charcoal text-white"
-    >
+    <section id="hero-section" className="w-full self-center bg-cc-charcoal text-white">
       <div className="container mx-auto pt-24">
         <div className="grid grid-cols-2">
           <div className="relative z-20 flex flex-col content-center justify-center">
-            <Eyebrow text="A podcast for the Every day Catholic" />
+            <div className="mb-4 uppercase text-inherit opacity-70">
+              A podcast for the Every day Catholic
+            </div>
             <div className="max-w-[47.50rem] overflow-hidden pb-1.5 text-7xl font-extrabold">
               <h1 className="max-w-[50.00rem] pb-3.5 pt-6">
                 When was the last time you had an encounter with Christ?
@@ -23,20 +20,27 @@ export function Hero() {
               Encounter begins with a simple prayer. Let us begin.
             </p>
             <div className="flex items-center gap-8">
-              <BtnMain text="Listen Now" link="/#" />
-              <LinkMain link="/#" text="Meet Fr. Jack Knight" />
+              <Link
+                className="relative max-w-full cursor-pointer overflow-hidden rounded-sm bg-white px-8 py-3 text-xl text-orange-400"
+                href="/#"
+              >
+                Listen Now
+              </Link>
+              <Link
+                href="/#"
+                className="relative inline-block max-w-full cursor-pointer overflow-hidden text-xl text-orange-400"
+              >
+                Meet Fr. Jack Knight
+              </Link>
             </div>
           </div>
           <div className="relative flex h-[80vh] w-[40vw] max-w-[46.88rem] flex-col items-center justify-center bg-zinc-700">
             <div className="mb-12 ml-12 mr-6 mt-6 inline-block h-full max-h-[56.25rem] w-[37.00rem] max-w-none pb-3 align-middle">
-              <Image
-                src={HeroImage}
-                alt="Fr. Jack Knight sitting in a local brewery."
-              />
+              <Image src={HeroImage} alt="Fr. Jack Knight sitting in a local brewery." />
             </div>
           </div>
         </div>
       </div>
     </section>
-  );
+  )
 }


### PR DESCRIPTION
### TL;DR

Implemented a new hero section for the Concrete Catholic page.

### What changed?

- Added a new hero section to the `ConcreteCatholicPage` component in `page.tsx`.
- Refactored the `Hero` component in `Hero.tsx` to use inline styles and remove dependencies on custom components.
- Replaced custom button and link components with Next.js `Link` components.
- Integrated the hero image directly into both components.

### How to test?

1. Navigate to the Concrete Catholic page.
2. Verify that the new hero section appears at the top of the page.
3. Check that the layout includes a two-column grid with text on the left and an image on the right.
4. Ensure that the "Listen Now" and "Meet Fr. Jack Knight" links are functional.
5. Confirm that the hero image of Fr. Jack Knight is displayed correctly.

### Why make this change?

This change simplifies the hero section implementation by reducing component dependencies and improving code maintainability. It also enhances the user interface with a more visually appealing and informative hero section, providing a better introduction to the Concrete Catholic podcast and its host.