### PR TITLE
refactor: migrate quote section information into home page

### DIFF
--- a/src/app/(frontend)/home/page.tsx
+++ b/src/app/(frontend)/home/page.tsx
@@ -1,4 +1,3 @@
-import { PrayerSection } from '../../../components/PrayerSection'
 import { AudienceSection } from '../../../components/AudienceSection'
 import { FAQSection } from '../../../components/FAQSection'
 import { ContactSection } from '../../../components/ContactSection'
@@ -14,7 +13,6 @@ import { ListenNowSection } from '../../../components/ListenNowSection'
 export default function Page() {
   return (
     <>
-      <PrayerSection />
       <QuoteSection
         image="/images/atlanta-traffic-guy-1200.jpg"
         alt=""

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -156,6 +156,41 @@ export default function ConcreteCatholicPage() {
           </div>
         </div>
       </section>
+      <section className="relative mt-44 flex min-h-[850px] w-[1536px] max-w-full flex-col items-center justify-center px-16 py-20 font-extrabold max-md:mt-10 max-md:pl-5">
+        <div className="absolute inset-0">
+          <Image
+            src="/images/atlanta-traffic-guy-1200.jpg"
+            alt=""
+            layout="fill"
+            objectFit="cover"
+            quality={100}
+          />
+        </div>
+        <div className="relative mb-10 mt-16 flex w-full max-w-[1370px] justify-between gap-5 bg-white bg-opacity-90 p-20 shadow-2xl">
+          <blockquote className="mt-24 flex flex-col self-end max-md:mt-10 max-md:max-w-full">
+            <p className="text-4xl leading-9 text-black max-md:max-w-full">
+              Being Christian is not the result of an ethical choice or a lofty idea, but the
+              encounter with an event, a person, which gives life a new horizon and a decisive
+              direction.
+            </p>
+            <cite className="mt-20 text-xl leading-5 tracking-wider text-gray-800 max-md:mt-10 max-md:max-w-full">
+              Pope Benedict XVI
+            </cite>
+            <div className="text-xs uppercase leading-5 tracking-wider text-zinc-400 max-md:max-w-full">
+              Deus Caritas Est
+            </div>
+          </blockquote>
+          <div className="aspect-[0.77] max-w-full shrink-0">
+            <Image
+              src="/images/atlanta-traffic-guy-1200.jpg"
+              alt=""
+              width={500}
+              height={650}
+              objectFit="cover"
+            />
+          </div>
+        </div>
+      </section>
       <section className="flex flex-col w-full max-md:max-w-full">
         <div className="flex flex-col w-full min-h-[998px] max-md:max-w-full">
           <div className="flex flex-1 w-full bg-gray-800 min-h-[934px] max-md:max-w-full" />

--- a/src/components/QuoteSection.tsx
+++ b/src/components/QuoteSection.tsx
@@ -1,53 +1,5 @@
-import Image from "next/image";
-import QuoteJackImage from "@/public/images/Concrete_Catholic_bnw-40.jpg";
-
-interface QuoteSectionProps {
-  image: string;
-  alt: string;
-  quoteContent: string;
-  quoteAuthor: string;
-  quoteSource: string;
-}
-
-export function QuoteSection({
-  image,
-  alt,
-  quoteAuthor,
-  quoteContent,
-  quoteSource,
-}: QuoteSectionProps) {
+export function QuoteSection() {
   return (
-    <section
-      id="quote-section"
-      className="relative mt-44 flex min-h-[850px] w-[1536px] max-w-full flex-col items-center justify-center px-16 py-20 font-extrabold max-md:mt-10 max-md:pl-5"
-    >
-      <Image
-        src={image}
-        alt="Background"
-        fill
-        objectFit="cover"
-        className="absolute inset-0"
-      />
-      <div className="relative mb-10 mt-16 flex w-full max-w-[1370px] justify-between gap-5 bg-white bg-opacity-90 p-20 shadow-2xl">
-        <blockquote className="mt-24 flex flex-col self-end max-md:mt-10 max-md:max-w-full">
-          <p className="text-4xl leading-9 text-black max-md:max-w-full">
-            {quoteContent}
-          </p>
-          <cite className="mt-20 text-xl leading-5 tracking-wider text-gray-800 max-md:mt-10 max-md:max-w-full">
-            {quoteAuthor}
-          </cite>
-          <div className="text-xs uppercase leading-5 tracking-wider text-zinc-400 max-md:max-w-full">
-            {quoteSource}
-          </div>
-        </blockquote>
-        <Image
-          src={QuoteJackImage}
-          alt={alt}
-          width={300}
-          height={390}
-          className="aspect-[0.77] max-w-full shrink-0"
-        />
-      </div>
-    </section>
-  );
+   
+  )
 }


### PR DESCRIPTION
### TL;DR

Removed the PrayerSection component and integrated the QuoteSection directly into the main page.

### What changed?

- Removed the import and usage of the PrayerSection component from the home page.
- Moved the QuoteSection content directly into the main page component.
- Simplified the QuoteSection component, removing all its content.

### How to test?

1. Navigate to the home page.
2. Verify that the prayer section is no longer present.
3. Ensure that the quote section appears correctly with the background image, quote text, and author information.
4. Check that the layout and styling of the quote section match the previous implementation.

### Why make this change?

This change streamlines the page structure by removing a separate component for the prayer section and integrating the quote section directly into the main page. This approach may improve performance by reducing component nesting and simplify the overall code structure.