### PR TITLE
chore: remove unneeded QuoteSection component

### DIFF
--- a/src/app/(frontend)/home/page.tsx
+++ b/src/app/(frontend)/home/page.tsx
@@ -1,7 +1,7 @@
 import { AudienceSection } from '../../../components/AudienceSection'
 import { FAQSection } from '../../../components/FAQSection'
 import { ContactSection } from '../../../components/ContactSection'
-import { QuoteSection } from '../../../components/QuoteSection'
+
 import { InviteSection } from '../../../components/InviteSection'
 import { BeConcreteSection } from '../../../components/BeConcreteSection'
 import { CoverSection } from '../../../components/CoverSection'
@@ -13,25 +13,12 @@ import { ListenNowSection } from '../../../components/ListenNowSection'
 export default function Page() {
   return (
     <>
-      <QuoteSection
-        image="/images/atlanta-traffic-guy-1200.jpg"
-        alt=""
-        quoteAuthor="Pope Benedict XVI"
-        quoteContent="Being Christian is not the result of an ethical choice or a lofty idea, but the encounter with an event, a person, which gives life a new horizon and a decisive direction."
-        quoteSource="Deus Caritas Est"
-      />
       <InviteSection />
       <AudienceSection />
       <SubscribeSection />
       <CoverSection />
       <BeConcreteSection />
-      <QuoteSection
-        image="/images/atlanta-traffic-guy-1200.jpg"
-        alt=""
-        quoteAuthor="Luigi Giussani"
-        quoteContent="The truly interesting question for man is neither logic, a fascinating game, nor demonstration, an inviting curiosity. Rather, the intriguing problem for man is how to adhere to reality, to become aware of reality."
-        quoteSource="The Religious Sense"
-      />
+
       <BioSection />
       <WhatIfSection />
       <ListenNowSection />

--- a/src/components/QuoteSection.tsx
+++ b/src/components/QuoteSection.tsx
@@ -1,5 +1,0 @@
-export function QuoteSection() {
-  return (
-   
-  )
-}


### PR DESCRIPTION
### TL;DR

Removed QuoteSection component and its usage from the home page.

### What changed?

- Removed the import of QuoteSection from the home page.
- Deleted two instances of QuoteSection component from the home page layout.
- Deleted the entire QuoteSection.tsx file.

### How to test?

1. Navigate to the home page.
2. Verify that no quote sections are visible on the page.
3. Ensure that the page layout remains intact without the removed quote sections.
4. Check that the removal of QuoteSection doesn't cause any console errors or visual inconsistencies.

### Why make this change?

This change simplifies the home page layout by removing the quote sections. It may have been decided that these quotes were not necessary for the user experience or that the information could be presented more effectively in other ways. The removal of this component also reduces the overall complexity of the page and potentially improves load times.