### PR TITLE
refactor: migrate code from WhatIf section into home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -697,6 +697,68 @@ export default function ConcreteCatholicPage() {
           </div>
         </div>
       </section>
+      <section id="what-if-section" className="py-24">
+        <div className="container mx-auto">
+          <div className="flex flex-col items-center justify-center text-sm">
+            <div className="relative w-[90%] max-w-[85.63rem]">
+              <div className="grid auto-cols-fr grid-cols-[1.4fr_1fr] grid-rows-[auto_auto] gap-x-10 gap-y-5">
+                <div className="col-start-2 col-end-3 row-start-1 row-end-2 pr-12">
+                  <div className="mb-4 uppercase text-inherit opacity-70">Imagine this...</div>
+
+                  <h3 className="mb-8 max-w-[26.25rem] text-[2.50rem] font-extrabold leading-none">
+                    What if you could encounter God in the ordinary?
+                  </h3>
+
+                  <ol className="mb-3 flex flex-wrap pl-8 text-xl font-bold">
+                    <li className="list-item basis-1/2 py-3 pr-5">
+                      <h5 className="mb-3 font-extrabold">
+                        Through every relationship in your life.
+                      </h5>
+                    </li>
+
+                    <li className="list-item basis-1/2 py-3 pr-5">
+                      <h5 className="mb-3 font-extrabold">
+                        Through your work, desires, and plans.
+                      </h5>
+                    </li>
+
+                    <li className="list-item basis-1/2 py-3 pr-5">
+                      <h5 className="mb-3 font-extrabold">
+                        Through your loneliness, boredom, and sadness.
+                      </h5>
+                    </li>
+
+                    <li className="list-item basis-1/2 py-3 pr-5">
+                      <h5 className="mb-3 font-extrabold">
+                        Through your joy, hope, and happiness.
+                      </h5>
+                    </li>
+                  </ol>
+                </div>
+
+                <div
+                  className='relative col-start-1 col-end-2 row-start-1 row-end-2 flex h-[37.50rem] flex-col items-center justify-center bg-[url("https://www.concretecatholic.com/images/knight-park-bench-small.jpg")] bg-cover blur-[1px]'
+                  id="div-4"
+                ></div>
+
+                <div className="relative col-start-1 col-end-3 row-start-2 row-end-3 -mt-16 flex w-[70%] min-w-[53.13rem] items-center justify-between justify-self-end">
+                  <div className="relative flex w-full min-w-[53.13rem] items-center justify-between bg-cc-sunset px-16 py-20 text-white">
+                    <h4 className="mr-28 max-w-[25.00rem] text-3xl font-extrabold">
+                      Jesus, reveal yourself to me in a real and concrete way today.
+                    </h4>
+                    <Link
+                      className="relative max-w-full cursor-pointer overflow-hidden rounded-sm bg-white px-8 py-3 text-xl text-orange-400"
+                      href="/"
+                    >
+                      Listen Now
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </>
   )
 }

--- a/src/components/WhatIfSection.tsx
+++ b/src/components/WhatIfSection.tsx
@@ -1,62 +1,7 @@
-import { Eyebrow } from "./Eyebrow";
-import { ListenCTA } from "./ListenCTA";
+import Link from 'next/link'
 
 export function WhatIfSection() {
   return (
-    <section id="what-if-section" className="py-24">
-      <div className="container mx-auto">
-        <div className="flex flex-col items-center justify-center text-sm">
-          <div className="relative w-[90%] max-w-[85.63rem]">
-            <div className="grid auto-cols-fr grid-cols-[1.4fr_1fr] grid-rows-[auto_auto] gap-x-10 gap-y-5">
-              <div className="col-start-2 col-end-3 row-start-1 row-end-2 pr-12">
-                <Eyebrow text="Imagine this..." />
-
-                <h3 className="mb-8 max-w-[26.25rem] text-[2.50rem] font-extrabold leading-none">
-                  What if you could encounter God in the ordinary?
-                </h3>
-
-                <ol className="mb-3 flex flex-wrap pl-8 text-xl font-bold">
-                  <li className="list-item basis-1/2 py-3 pr-5">
-                    <h5 className="mb-3 font-extrabold">
-                      Through every relationship in your life.
-                    </h5>
-                  </li>
-
-                  <li className="list-item basis-1/2 py-3 pr-5">
-                    <h5 className="mb-3 font-extrabold">
-                      Through your work, desires, and plans.
-                    </h5>
-                  </li>
-
-                  <li className="list-item basis-1/2 py-3 pr-5">
-                    <h5 className="mb-3 font-extrabold">
-                      Through your loneliness, boredom, and sadness.
-                    </h5>
-                  </li>
-
-                  <li className="list-item basis-1/2 py-3 pr-5">
-                    <h5 className="mb-3 font-extrabold">
-                      Through your joy, hope, and happiness.
-                    </h5>
-                  </li>
-                </ol>
-              </div>
-
-              <div
-                className='relative col-start-1 col-end-2 row-start-1 row-end-2 flex h-[37.50rem] flex-col items-center justify-center bg-[url("https://www.concretecatholic.com/images/knight-park-bench-small.jpg")] bg-cover blur-[1px]'
-                id="div-4"
-              ></div>
-
-              <div className="relative col-start-1 col-end-3 row-start-2 row-end-3 -mt-16 flex w-[70%] min-w-[53.13rem] items-center justify-between justify-self-end">
-                <ListenCTA
-                  text="Jesus, reveal yourself to me in a real and concrete way today."
-                  link="/"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </section>
-  );
+   
+  )
 }


### PR DESCRIPTION
### TL;DR

Added a new "What If" section to the main page, showcasing ways to encounter God in everyday life.

### What changed?

- Introduced a new `<section>` with the id "what-if-section" in the `ConcreteCatholicPage` component.
- The section includes a grid layout with text content, an image background, and a call-to-action.
- Removed the content from the `WhatIfSection` component, leaving it empty.

### How to test?

1. Navigate to the main page of the application.
2. Scroll down to find the new "What If" section.
3. Verify that the section displays correctly with the following elements:
   - "Imagine this..." heading
   - "What if you could encounter God in the ordinary?" title
   - Four list items describing ways to encounter God
   - Background image of a knight on a park bench
   - Call-to-action box with the text "Jesus, reveal yourself to me in a real and concrete way today." and a "Listen Now" button

### Why make this change?

This change aims to enhance the user experience by providing a visually appealing and thought-provoking section that encourages users to consider encountering God in their daily lives. By moving the content directly into the main page component, it simplifies the structure and potentially improves performance by reducing the number of separate components.