### PR TITLE
chore: remove unneeded WhatIf component

### DIFF
--- a/src/app/(frontend)/home/page.tsx
+++ b/src/app/(frontend)/home/page.tsx
@@ -6,7 +6,6 @@ import { BeConcreteSection } from '../../../components/BeConcreteSection'
 import { CoverSection } from '../../../components/CoverSection'
 import { SubscribeSection } from '../../../components/SubscribeSection'
 import { BioSection } from '../../../components/BioSection'
-import { WhatIfSection } from '../../../components/WhatIfSection'
 import { ListenNowSection } from '../../../components/ListenNowSection'
 
 export default function Page() {
@@ -18,7 +17,6 @@ export default function Page() {
       <BeConcreteSection />
 
       <BioSection />
-      <WhatIfSection />
       <ListenNowSection />
       <FAQSection />
       <ContactSection />

--- a/src/components/WhatIfSection.tsx
+++ b/src/components/WhatIfSection.tsx
@@ -1,7 +1,0 @@
-import Link from 'next/link'
-
-export function WhatIfSection() {
-  return (
-   
-  )
-}


### PR DESCRIPTION
### TL;DR

Removed the WhatIfSection component from the home page.

### What changed?

- Removed the import of `WhatIfSection` from the home page component.
- Deleted the `<WhatIfSection />` component from the JSX in the home page.
- Completely removed the `WhatIfSection.tsx` file.

### How to test?

1. Navigate to the home page.
2. Verify that the "What If" section is no longer visible.
3. Ensure that the removal of this section doesn't negatively impact the layout or functionality of surrounding components.

### Why make this change?

The WhatIfSection was likely deemed unnecessary or redundant for the current design of the home page. Removing it simplifies the page structure and potentially improves load times by reducing the number of components rendered.