### PR TITLE
feat(ui): add social icons to footer

### DIFF
--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -22,29 +22,6 @@ const ConcreteCatholic: React.FC = () => {
   return (
     <>
       <div className="flex flex-col justify-center">
-        <header className="flex flex-wrap gap-10 justify-between items-center px-72 py-4 w-full text-lg leading-none text-white bg-gray-800 border-solid border-b-[0.5px] border-b-white border-b-opacity-50 max-md:px-5 max-md:max-w-full">
-          <img
-            loading="lazy"
-            src={logoSrc}
-            alt="Logo"
-            className="object-contain shrink-0 self-stretch my-auto aspect-[3.12] w-[156px]"
-          />
-          <nav className="flex gap-10 items-start self-stretch my-auto min-w-[240px] max-md:max-w-full">
-            {navItems.map((item, index) => (
-              <div key={index} className={`flex gap-1 items-end ${item.className || ''}`}>
-                <div>{item.label}</div>
-                {item.iconSrc && (
-                  <img
-                    loading="lazy"
-                    src={item.iconSrc}
-                    alt=""
-                    className="object-contain shrink-0 w-6 aspect-square"
-                  />
-                )}
-              </div>
-            ))}
-          </nav>
-        </header>
         <main>
           <section className="flex flex-wrap gap-10 items-center px-64 py-40 w-full bg-gray-800 max-md:px-5 max-md:py-24 max-md:max-w-full">
             <div className="flex flex-col grow shrink items-start self-stretch pb-8 my-auto min-w-[240px] w-[525px] max-md:max-w-full">

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -59,13 +59,57 @@ export function Footer() {
                   className="flex items-center text-white/70 transition-colors hover:text-yellow-600"
                   aria-label={`${platform} link`}
                 >
-                  <Image
-                    src={`/images/${platform.toLowerCase()}-icon.svg`}
-                    alt={`${platform} Icon`}
-                    width={24}
-                    height={24}
-                    className="mr-2"
-                  />
+                  {platform === 'Instagram' ? (
+                    <svg
+                      width="24"
+                      height="24"
+                      stroke-width="1.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      color="#ffffff"
+                      className="mr-2"
+                    >
+                      <path
+                        d="M12 16C14.2091 16 16 14.2091 16 12C16 9.79086 14.2091 8 12 8C9.79086 8 8 9.79086 8 12C8 14.2091 9.79086 16 12 16Z"
+                        stroke="#ffffff"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      ></path>
+                      <path
+                        d="M3 16V8C3 5.23858 5.23858 3 8 3H16C18.7614 3 21 5.23858 21 8V16C21 18.7614 18.7614 21 16 21H8C5.23858 21 3 18.7614 3 16Z"
+                        stroke="#ffffff"
+                        stroke-width="1.5"
+                      ></path>
+                      <path
+                        d="M17.5 6.51L17.51 6.49889"
+                        stroke="#ffffff"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      ></path>
+                    </svg>
+                  ) : (
+                    <svg
+                      width="24"
+                      height="24"
+                      stroke-width="1.5"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                      color="#ffffff"
+                      className="mr-2"
+                    >
+                      <path
+                        d="M17 2H14C12.6739 2 11.4021 2.52678 10.4645 3.46447C9.52678 4.40215 9 5.67392 9 7V10H6V14H9V22H13V14H16L17 10H13V7C13 6.73478 13.1054 6.48043 13.2929 6.29289C13.4804 6.10536 13.7348 6 14 6H17V2Z"
+                        stroke="#ffffff"
+                        stroke-width="1.5"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                      ></path>
+                    </svg>
+                  )}
                   <span>{platform}</span>
                 </a>
               ))}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,78 +1,45 @@
 import Link from 'next/link'
 import Image from 'next/image'
 export function Header() {
-  const logo =
-    'https://cdn.builder.io/api/v1/image/assets/TEMP/a1500297b3d9a173a0bd66cba0a672134d9faae8da730743ad7daff0bf978cfc?placeholderIfAbsent=true&apiKey=687549a059be4b889b95799647c9bdf8'
-
   return (
-    <>
-      <header className="flex flex-wrap gap-10 justify-between items-center px-72 py-4 w-full text-lg leading-none text-white bg-gray-800 border-solid border-b-[0.5px] border-b-white border-b-opacity-50 max-md:px-5 max-md:max-w-full">
-        <img
-          loading="lazy"
-          src={logo}
-          alt="Logo"
-          className="object-contain shrink-0 self-stretch my-auto aspect-[3.12] w-[156px]"
-        />
-        <nav className="flex gap-10 items-start self-stretch my-auto min-w-[240px] max-md:max-w-full">
+    <header
+      id="header"
+      className="z-10 w-full bg-cc-charcoal px-4 pt-2 text-white text-opacity-75 sm:px-12"
+      role="banner"
+    >
+      <div className="container mx-auto flex w-full max-w-screen-2xl items-center justify-between gap-5">
+        <Link href="/" className="cursor-pointer">
+          <Image
+            src="/images/cc-logo.png"
+            alt="Concrete Catholic Logo"
+            width={175}
+            height={96}
+            priority
+          />
+        </Link>
+        <nav
+          className="my-auto hidden flex-col items-center text-sm leading-5 sm:flex sm:flex-row"
+          role="navigation"
+        >
           {[
-            { label: 'Episodes', hasIcon: true },
-            { label: 'Meet Fr. Jack', hasIcon: false },
-            { label: 'Contact', hasIcon: false },
+            { text: 'Meet Fr. Jack', link: '/meet-fr-jack' },
+            { text: 'About Us', link: '/about' },
+            { text: 'Contact', link: '/contact' },
+            { text: 'Listen Now', link: '/listen', isActive: true },
           ].map((item, index) => (
-            <div key={index} className="flex gap-1 items-end whitespace-nowrap rounded">
-              <div>{item.label}</div>
-              {item.hasIcon && (
-                <img
-                  loading="lazy"
-                  src="https://cdn.builder.io/api/v1/image/assets/TEMP/a3aa2fc93681c8eb896a27a81eda5fed7a935f5410217d1754c25b538e4485f6?placeholderIfAbsent=true&apiKey=687549a059be4b889b95799647c9bdf8"
-                  alt=""
-                  className="object-contain shrink-0 w-6 aspect-square"
-                />
-              )}
-            </div>
+            <Link
+              href={item.link}
+              key={index}
+              className={`my-auto self-stretch px-5 py-1 hover:text-yellow-400 ${
+                item.isActive ? 'text-xl text-yellow-600' : 'tracking-[2px]'
+              }`}
+            >
+              {item.text}
+              {item.isActive && <div className="mt-2 h-0.5 shrink-0 bg-orange-400" />}
+            </Link>
           ))}
-          <button className="text-yellow-600 rounded">Listen Now</button>
         </nav>
-      </header>
-      <header
-        id="header"
-        className="z-10 w-full bg-cc-charcoal px-4 pt-2 text-white text-opacity-75 sm:px-12"
-        role="banner"
-      >
-        <div className="container mx-auto flex w-full max-w-screen-2xl items-center justify-between gap-5">
-          <Link href="/" className="cursor-pointer">
-            <Image
-              src="/images/cc-logo.png"
-              alt="Concrete Catholic Logo"
-              width={175}
-              height={96}
-              priority
-            />
-          </Link>
-          <nav
-            className="my-auto hidden flex-col items-center text-sm leading-5 sm:flex sm:flex-row"
-            role="navigation"
-          >
-            {[
-              { text: 'Meet Fr. Jack', link: '/meet-fr-jack' },
-              { text: 'About Us', link: '/about' },
-              { text: 'Contact', link: '/contact' },
-              { text: 'Listen Now', link: '/listen', isActive: true },
-            ].map((item, index) => (
-              <Link
-                href={item.link}
-                key={index}
-                className={`my-auto self-stretch px-5 py-1 hover:text-yellow-400 ${
-                  item.isActive ? 'text-xl text-yellow-600' : 'tracking-[2px]'
-                }`}
-              >
-                {item.text}
-                {item.isActive && <div className="mt-2 h-0.5 shrink-0 bg-orange-400" />}
-              </Link>
-            ))}
-          </nav>
-        </div>
-      </header>
-    </>
+      </div>
+    </header>
   )
 }


### PR DESCRIPTION
### TL;DR

Streamlined header component and updated social media icons in footer.

### What changed?

- Removed duplicate header from the about page
- Simplified the Header component by removing the old implementation and keeping the more modern version
- Updated social media icons in the Footer component:
  - Replaced Image components with inline SVG for Instagram and Facebook icons
  - Added conditional rendering to display the correct icon for each platform

### How to test?

1. Navigate to the about page and verify that only one header is present
2. Check all pages to ensure the header is consistent and functional
3. Visit the footer section and confirm that the Instagram and Facebook icons are displayed correctly
4. Verify that the social media icons in the footer change color on hover

### Why make this change?

This change improves code consistency and reduces duplication by standardizing the header across all pages. The use of inline SVGs for social media icons in the footer enhances performance by reducing HTTP requests and provides better control over icon styling. These updates contribute to a more maintainable and efficient codebase.